### PR TITLE
Add requirejs paths for full, standard and basic.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,15 @@
         <upstream.version>4.4.7</upstream.version>
         <upstream.url>http://download.cksource.com/CKEditor/CKEditor/CKEditor%20${upstream.version}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
+        <requirejs>
+            {
+                "paths": {
+                    "ckeditor-full": "full/ckeditor",
+                    "ckeditor-standard": "standard/ckeditor",
+                    "ckeditor-basic": "basic/ckeditor"
+                }
+            }
+        </requirejs>
     </properties>
 
     <developers>


### PR DESCRIPTION
Depend on "ckeditor-full", "ckeditor-standard" or "ckeditor-basic"

Update this webjar to publish requirejs paths to simplify usage.