### PR TITLE
Change version to 4.7.0 following release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>ckeditor</artifactId>
-    <version>4.6.3-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
     <name>CKEditor</name>
     <description>WebJar for CKEditor</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
CKEDITOR 4.7.0 was released on 25 May 2017.